### PR TITLE
feat: add P controller for velocity planning

### DIFF
--- a/src/autoware_practice_course/CMakeLists.txt
+++ b/src/autoware_practice_course/CMakeLists.txt
@@ -15,6 +15,7 @@ ament_auto_find_build_dependencies()
 
 ament_auto_add_executable(vehicle_forward  src/vehicle/forward.cpp)
 ament_auto_add_executable(vehicle_backward src/vehicle/backward.cpp)
+ament_auto_add_executable(p_controller src/velocity_planning/p_controller.cpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -5,7 +5,7 @@
 namespace autoware_practice_course
 {
 
-SampleNode::SampleNode() : Node("sample_node"), target_velocity_(1.0), kp_(0.5)
+SampleNode::SampleNode() : Node("sample_node"), target_velocity_(1.0), kp_(0.01)
 {
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -29,7 +29,7 @@ void SampleNode::on_timer()
   
   double velocity_error = target_velocity_ - current_velocity_;
   command.longitudinal.acceleration = kp_ * velocity_error;
-  command.longitudinal.speed = 0.0;
+  command.longitudinal.speed = target_velocity_;
   
   command.lateral.steering_tire_angle = 0.0;
   

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -1,0 +1,48 @@
+#include "p_controller.hpp"
+
+#include <memory>
+
+namespace autoware_practice_course
+{
+
+SampleNode::SampleNode() : Node("sample_node"), target_velocity_(1.0), kp_(0.5)
+{
+  pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
+  
+  velocity_subscriber_ = create_subscription<VelocityReport>(
+    "/simulator/status/velocity", 10, [this](const VelocityReport::SharedPtr msg) {
+      current_velocity_ = msg->longitudinal_velocity; 
+  });
+
+  const auto period = rclcpp::Rate(10).period();
+  timer_ = rclcpp::create_timer(this, get_clock(), period, [this] { on_timer(); });
+}
+
+void SampleNode::on_timer()
+{
+  const auto stamp = now();
+
+  AckermannControlCommand command;
+  command.stamp = stamp;
+  
+  double velocity_error = target_velocity_ - current_velocity_;
+  command.longitudinal.acceleration = kp_ * velocity_error;
+  
+  command.longitudinal.speed = target_velocity_;
+  command.longitudinal.speed = 0.0;
+  
+  command.lateral.steering_tire_angle = 0.0;
+  
+  pub_command_->publish(command);
+}
+
+} 
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<autoware_practice_course::SampleNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -29,8 +29,6 @@ void SampleNode::on_timer()
   
   double velocity_error = target_velocity_ - current_velocity_;
   command.longitudinal.acceleration = kp_ * velocity_error;
-  
-  command.longitudinal.speed = target_velocity_;
   command.longitudinal.speed = 0.0;
   
   command.lateral.steering_tire_angle = 0.0;

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -12,7 +12,7 @@ SampleNode::SampleNode() : Node("p_controller")
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   
   velocity_subscriber_ = create_subscription<VelocityReport>(
-    "/simulator/status/velocity", 10, [this](const VelocityReport::SharedPtr msg) {
+    "/vehicle/status/velocity_status", 10, [this](const VelocityReport::SharedPtr msg) {
       current_velocity_ = msg->longitudinal_velocity; 
   });
 

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -5,8 +5,10 @@
 namespace autoware_practice_course
 {
 
-SampleNode::SampleNode() : Node("p_controller"), target_velocity_(1.0), kp_(0.01)
+SampleNode::SampleNode() : Node("p_controller")
 {
+  kp_ = 0.5;
+  target_velocity_ = 1.0;
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   
   velocity_subscriber_ = create_subscription<VelocityReport>(

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -5,7 +5,7 @@
 namespace autoware_practice_course
 {
 
-SampleNode::SampleNode() : Node("sample_node"), target_velocity_(1.0), kp_(0.01)
+SampleNode::SampleNode() : Node("p_controller"), target_velocity_(1.0), kp_(0.01)
 {
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -7,8 +7,12 @@ namespace autoware_practice_course
 
 SampleNode::SampleNode() : Node("p_controller")
 {
-  kp_ = 0.5;
-  target_velocity_ = 1.0;
+  this->declare_parameter<double>("kp", 0.0);
+  this->declare_parameter<double>("target_velocity", 1.0);
+
+  this->get_parameter("kp", kp_);
+  this->get_parameter("target_velocity", target_velocity_);
+
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   
   velocity_subscriber_ = create_subscription<VelocityReport>(

--- a/src/autoware_practice_course/src/velocity_planning/p_controller.hpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.hpp
@@ -1,0 +1,39 @@
+#ifndef P_CONTROLLER_HPP_
+#define P_CONTROLLER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+
+namespace autoware_practice_course
+{
+
+class SampleNode : public rclcpp::Node
+{
+public:
+  SampleNode();
+
+private:
+  using AckermannControlCommand = autoware_auto_control_msgs::msg::AckermannControlCommand;
+  using VelocityReport = autoware_auto_vehicle_msgs::msg::VelocityReport;
+
+  void on_timer();
+
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_command_;
+
+  rclcpp::Subscription<VelocityReport>::SharedPtr velocity_subscriber_;
+
+  double current_velocity_ = 0.0;
+
+  double target_velocity_ = 0.0;
+
+  double kp_ = 0.0;
+
+  void velocity_callback(const VelocityReport::SharedPtr msg);
+};
+
+} 
+
+#endif


### PR DESCRIPTION
https://github.com/AutomotiveAIChallenge/aichallenge-documentation/issues/11 に基づいて、速度を比例制御するコントローラです。
```
ros2 run autoware_practice_course vehicle_forward
```

の代わりに以下を実行するとコントローラが動きます。目標速度は1m/sです。

```
ros2 run autoware_practice_course p_controller
```

https://github.com/AutomotiveAIChallenge/aichallenge-documentation/pull/13 こちらと対応しています。

判定は一旦無しにしてマージをしようと思います。よろしくお願いします。