### PR TITLE
fix: align topics around localizer with Autoware

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -2,8 +2,8 @@ repositories:
   interfaces/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: main
+    version: 90ed3f1f3371d75eb30b6e7d2acb88ccec4e8030
   interfaces/autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
+    version: f6642370c6f4f42a5dc0b6c1fc4a21396d4dc34c

--- a/src/autoware_practice_driver/launch/vehicle.launch.xml
+++ b/src/autoware_practice_driver/launch/vehicle.launch.xml
@@ -19,6 +19,8 @@
     <param name="input_topic" value="/simulator/status/gear"/>
     <param name="output_topic" value="/vehicle/status/gear_status"/>
   </node>
-  <node pkg="autoware_practice_gnss_poser" exec="pose_transformer" name="pose_transformer">
+  <node pkg="autoware_practice_gnss_poser" exec="pose_transformer" name="gnss_poser">
+  </node>
+  <node pkg="autoware_practice_gyro_odometer" exec="velocity_transformer" name="gyro_odometer">
   </node>
 </launch>

--- a/src/autoware_practice_driver/launch/vehicle.launch.xml
+++ b/src/autoware_practice_driver/launch/vehicle.launch.xml
@@ -23,4 +23,6 @@
   </node>
   <node pkg="autoware_practice_gyro_odometer" exec="velocity_transformer" name="gyro_odometer">
   </node>
+  <node pkg="autoware_practice_localizer" exec="localizer" name="localizer">
+  </node>
 </launch>

--- a/src/autoware_practice_driver/launch/vehicle.launch.xml
+++ b/src/autoware_practice_driver/launch/vehicle.launch.xml
@@ -19,4 +19,6 @@
     <param name="input_topic" value="/simulator/status/gear"/>
     <param name="output_topic" value="/vehicle/status/gear_status"/>
   </node>
+  <node pkg="autoware_practice_gnss_poser" exec="pose_transformer" name="pose_transformer">
+  </node>
 </launch>

--- a/src/autoware_practice_gnss_poser/CMakeLists.txt
+++ b/src/autoware_practice_gnss_poser/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(autoware_practice_gnss_poser)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+add_executable(pose_transformer src/pose_transformer.cpp)
+ament_target_dependencies(pose_transformer rclcpp geometry_msgs)
+install(TARGETS
+  pose_transformer
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/autoware_practice_gnss_poser/package.xml
+++ b/src/autoware_practice_gnss_poser/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_practice_gnss_poser</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="norikenpi@gmail.com">masahirokubota</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/autoware_practice_gnss_poser/src/pose_transformer.cpp
+++ b/src/autoware_practice_gnss_poser/src/pose_transformer.cpp
@@ -1,0 +1,48 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/pose_with_covariance.hpp"
+
+class PoseTransformer : public rclcpp::Node
+{
+public:
+    PoseTransformer() : Node("pose_transformer")
+    {
+        publisher_ = this->create_publisher<geometry_msgs::msg::PoseWithCovariance>("/sensing/gnss/pose_with_covariance", 10);
+        subscription_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+            "/simulator/ground_truth/pose", 10, std::bind(&PoseTransformer::pose_callback, this, std::placeholders::_1));
+    }
+
+private:
+    void pose_callback(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+    {
+        geometry_msgs::msg::PoseWithCovariance new_msg;
+        new_msg.pose = msg->pose; // Directly assign the Pose part
+        
+        // Set a dummy covariance matrix
+        for (int i = 0; i < 36; ++i) {
+            new_msg.covariance[i] = 0.0; // Set all covariance to 0.0 for simplicity
+        }
+
+        // Set some values to covariance for demonstration
+        new_msg.covariance[0] = 0.1; // Variance in x
+        new_msg.covariance[7] = 0.1; // Variance in y
+        new_msg.covariance[14] = 0.1; // Variance in z
+        new_msg.covariance[21] = 0.01; // Variance in rotation around X
+        new_msg.covariance[28] = 0.01; // Variance in rotation around Y
+        new_msg.covariance[35] = 0.01; // Variance in rotation around Z
+
+        publisher_->publish(new_msg);
+    }
+
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseWithCovariance>::SharedPtr publisher_;
+};
+
+int main(int argc, char * argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<PoseTransformer>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/autoware_practice_gyro_odometer/CMakeLists.txt
+++ b/src/autoware_practice_gyro_odometer/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(autoware_practice_gyro_odometer)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(autoware_auto_vehicle_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_executable(velocity_transformer src/velocity_transformer.cpp)
+ament_target_dependencies(velocity_transformer rclcpp geometry_msgs autoware_auto_vehicle_msgs)
+install(TARGETS
+  velocity_transformer
+  DESTINATION lib/${PROJECT_NAME})
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/autoware_practice_gyro_odometer/package.xml
+++ b/src/autoware_practice_gyro_odometer/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_practice_gyro_odometer</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="norikenpi@gmail.com">masahirokubota</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/autoware_practice_gyro_odometer/src/velocity_transformer.cpp
+++ b/src/autoware_practice_gyro_odometer/src/velocity_transformer.cpp
@@ -1,0 +1,47 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist_with_covariance.hpp"
+#include "autoware_auto_vehicle_msgs/msg/velocity_report.hpp"
+
+class VelocityTransformer : public rclcpp::Node
+{
+public:
+    VelocityTransformer() : Node("velocity_transformer")
+    {
+        publisher_ = this->create_publisher<geometry_msgs::msg::TwistWithCovariance>("twist_estimator/twist_with_covariance", 10);
+        subscription_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+            "/vehicle/status/velocity_status", 10, std::bind(&VelocityTransformer::velocity_callback, this, std::placeholders::_1));
+    }
+
+private:
+    void velocity_callback(const autoware_auto_vehicle_msgs::msg::VelocityReport::SharedPtr msg)
+    {
+        geometry_msgs::msg::TwistWithCovariance twist_msg;
+        twist_msg.twist.linear.x = msg->longitudinal_velocity;
+        twist_msg.twist.linear.y = msg->lateral_velocity;
+        twist_msg.twist.angular.z = msg->heading_rate;
+
+        // Initialize covariance as zero for simplicity, just an example
+        for (int i = 0; i < 36; ++i) {
+            twist_msg.covariance[i] = 0.0;
+        }
+        // Setting specific covariance values for demonstration
+        twist_msg.covariance[0] = 0.01; // Variance of longitudinal velocity
+        twist_msg.covariance[7] = 0.01; // Variance of lateral velocity
+        twist_msg.covariance[35] = 0.01; // Variance of heading rate
+
+        publisher_->publish(twist_msg);
+    }
+
+
+    rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistWithCovariance>::SharedPtr publisher_;
+};
+
+int main(int argc, char * argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<VelocityTransformer>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/autoware_practice_localizer/CMakeLists.txt
+++ b/src/autoware_practice_localizer/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(autoware_practice_localizer)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+
+add_executable(localizer src/localizer.cpp)
+ament_target_dependencies(localizer rclcpp geometry_msgs nav_msgs)
+install(TARGETS
+  localizer
+  DESTINATION lib/${PROJECT_NAME})
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/autoware_practice_localizer/package.xml
+++ b/src/autoware_practice_localizer/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_practice_localizer</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="norikenpi@gmail.com">masahirokubota</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/autoware_practice_localizer/src/localizer.cpp
+++ b/src/autoware_practice_localizer/src/localizer.cpp
@@ -1,0 +1,60 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/pose_with_covariance.hpp"
+#include "geometry_msgs/msg/twist_with_covariance.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+class Localizer : public rclcpp::Node
+{
+public:
+    Localizer() : Node("localizer")
+    {
+        publisher_ = this->create_publisher<nav_msgs::msg::Odometry>("/localization/kinematic_state", 10);
+        pose_subscriber_ = this->create_subscription<geometry_msgs::msg::PoseWithCovariance>(
+            "/sensing/gnss/pose_with_covariance", 10, std::bind(&Localizer::pose_callback, this, std::placeholders::_1));
+        twist_subscriber_ = this->create_subscription<geometry_msgs::msg::TwistWithCovariance>(
+            "twist_estimator/twist_with_covariance", 10, std::bind(&Localizer::twist_callback, this, std::placeholders::_1));
+    }
+
+private:
+    void pose_callback(const geometry_msgs::msg::PoseWithCovariance::SharedPtr msg)
+    {
+        last_pose_ = *msg;
+        publish_odometry();
+    }
+
+    void twist_callback(const geometry_msgs::msg::TwistWithCovariance::SharedPtr msg)
+    {
+        last_twist_ = *msg;
+        publish_odometry();
+    }
+
+    void publish_odometry()
+    {
+        if (last_pose_ && last_twist_) {
+            nav_msgs::msg::Odometry odom;
+            odom.header.stamp = this->get_clock()->now();
+            odom.header.frame_id = "odom";
+            odom.child_frame_id = "base_link";
+            odom.pose = *last_pose_;
+            odom.twist = *last_twist_;
+            publisher_->publish(odom);
+            last_pose_.reset();
+            last_twist_.reset();
+        }
+    }
+
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr publisher_;
+    rclcpp::Subscription<geometry_msgs::msg::PoseWithCovariance>::SharedPtr pose_subscriber_;
+    rclcpp::Subscription<geometry_msgs::msg::TwistWithCovariance>::SharedPtr twist_subscriber_;
+    std::optional<geometry_msgs::msg::PoseWithCovariance> last_pose_;
+    std::optional<geometry_msgs::msg::TwistWithCovariance> last_twist_;
+};
+
+int main(int argc, char * argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<Localizer>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/autoware_practice_simulator/src/controller.cpp
+++ b/src/autoware_practice_simulator/src/controller.cpp
@@ -81,6 +81,7 @@ void VehicleController::update(double dt)
 
   constexpr double steer_eps = 1e-3;
   const double radius = (std::abs(actual_steer_) < steer_eps) ? 0.0 : specs_.wheel_base / std::tan(actual_steer_);
+  heading_rate_ = (radius == 0.0) ? 0.0 : actual_speed_ / radius;
   kinematics_->update(dt, ArcPath{radius, actual_speed_});
 }
 
@@ -128,6 +129,8 @@ void VehicleController::publish(const rclcpp::Time & stamp)
     msg.header.stamp = stamp;
     msg.header.frame_id = "base_link";
     msg.longitudinal_velocity = actual_speed_;
+    msg.lateral_velocity = 0.0;  
+    msg.heading_rate = heading_rate_;
     pub_velocity_->publish(msg);
   }
 

--- a/src/autoware_practice_simulator/src/controller.hpp
+++ b/src/autoware_practice_simulator/src/controller.hpp
@@ -62,6 +62,7 @@ private:
   double target_speed_;
   double target_accel_;
   double target_steer_;
+  double heading_rate_;
 };
 
 }  // namespace autoware_practice_simulator


### PR DESCRIPTION
- 使用するメッセージ型をAIチャレンジで用いるバージョンと同じにしました。
- シミュレータがheading_rateを計算するようにしました。
- gnss_poserとgyro_odometerはトピックの名前と型を変更しているだけです。
- localizerは単純にposeとtwistを合体させるだけです。


↓本PRによって変更されたLocalizer周りのトピックやノード
![autoware-practice](https://github.com/AutomotiveAIChallenge/autoware-practice/assets/42679530/46489aad-727c-4b3d-91b1-0bcff44bc8f7)

参考：Autowareのノードマップ[[url](https://app.diagrams.net/?lightbox=1#Uhttps%3A%2F%2Fautowarefoundation.github.io%2Fautoware-documentation%2Fmain%2Fdesign%2Fautoware-architecture%2Fnode-diagram%2Foverall-node-diagram-autoware-universe.drawio.svg#%7B%22pageId%22%3A%22T6t2FfeAp1iw48vGkmOz%22%7D)]
![image](https://github.com/AutomotiveAIChallenge/autoware-practice/assets/42679530/68cb17fb-342e-4465-b3fb-6b578273ee9a)
