### PR TITLE
refactor: remove unnecessary 'this->' for better readability

### DIFF
--- a/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
+++ b/src/autoware_practice_course/src/velocity_planning/p_controller.cpp
@@ -7,11 +7,11 @@ namespace autoware_practice_course
 
 SampleNode::SampleNode() : Node("p_controller")
 {
-  this->declare_parameter<double>("kp", 0.0);
-  this->declare_parameter<double>("target_velocity", 1.0);
+  declare_parameter<double>("kp", 0.0);
+  declare_parameter<double>("target_velocity", 1.0);
 
-  this->get_parameter("kp", kp_);
-  this->get_parameter("target_velocity", target_velocity_);
+  get_parameter("kp", kp_);
+  get_parameter("target_velocity", target_velocity_);
 
   pub_command_ = create_publisher<AckermannControlCommand>("/control/command/control_cmd", rclcpp::QoS(1));
   

--- a/src/autoware_practice_dummy_localizer/src/dummy_localizer.cpp
+++ b/src/autoware_practice_dummy_localizer/src/dummy_localizer.cpp
@@ -8,10 +8,10 @@ class DummyLocalizer : public rclcpp::Node
 public:
     DummyLocalizer() : Node("dummy_localizer")
     {
-        publisher_ = this->create_publisher<nav_msgs::msg::Odometry>("/localization/kinematic_state", 10);
-        pose_subscriber_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+        publisher_ = create_publisher<nav_msgs::msg::Odometry>("/localization/kinematic_state", 10);
+        pose_subscriber_ = create_subscription<geometry_msgs::msg::PoseStamped>(
             "/simulator/ground_truth/pose", 10, std::bind(&DummyLocalizer::pose_callback, this, std::placeholders::_1));
-        twist_subscriber_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+        twist_subscriber_ = create_subscription<geometry_msgs::msg::TwistStamped>(
             "/simulator/ground_truth/twist", 10, std::bind(&DummyLocalizer::twist_callback, this, std::placeholders::_1));
     }
 
@@ -32,7 +32,7 @@ private:
     {
         if (last_pose_ && last_twist_) {
             nav_msgs::msg::Odometry odom;
-            odom.header.stamp = this->get_clock()->now();
+            odom.header.stamp = now();
             odom.header.frame_id = "odom";
             odom.child_frame_id = "base_link";
             odom.pose.pose = *last_pose_;

--- a/src/autoware_practice_gnss_poser/src/pose_transformer.cpp
+++ b/src/autoware_practice_gnss_poser/src/pose_transformer.cpp
@@ -7,8 +7,8 @@ class PoseTransformer : public rclcpp::Node
 public:
     PoseTransformer() : Node("pose_transformer")
     {
-        publisher_ = this->create_publisher<geometry_msgs::msg::PoseWithCovariance>("/sensing/gnss/pose_with_covariance", 10);
-        subscription_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+        publisher_ = create_publisher<geometry_msgs::msg::PoseWithCovariance>("/sensing/gnss/pose_with_covariance", 10);
+        subscription_ = create_subscription<geometry_msgs::msg::PoseStamped>(
             "/simulator/ground_truth/pose", 10, std::bind(&PoseTransformer::pose_callback, this, std::placeholders::_1));
     }
 

--- a/src/autoware_practice_gyro_odometer/src/velocity_transformer.cpp
+++ b/src/autoware_practice_gyro_odometer/src/velocity_transformer.cpp
@@ -7,8 +7,8 @@ class VelocityTransformer : public rclcpp::Node
 public:
     VelocityTransformer() : Node("velocity_transformer")
     {
-        publisher_ = this->create_publisher<geometry_msgs::msg::TwistWithCovariance>("/localization/twist_estimator/twist_with_covariance", 10);
-        subscription_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+        publisher_ = create_publisher<geometry_msgs::msg::TwistWithCovariance>("/localization/twist_estimator/twist_with_covariance", 10);
+        subscription_ = create_subscription<autoware_auto_vehicle_msgs::msg::VelocityReport>(
             "/vehicle/status/velocity_status", 10, std::bind(&VelocityTransformer::velocity_callback, this, std::placeholders::_1));
     }
 


### PR DESCRIPTION
必要ない`this->`は消去。`clock()->now()`も`now()`で十分なので変更
https://github.com/AutomotiveAIChallenge/autoware-practice/issues/23
