### PR TITLE
feat: use object_centers.csv in share directory

### DIFF
--- a/src/autoware_practice_lidar_simulator/CMakeLists.txt
+++ b/src/autoware_practice_lidar_simulator/CMakeLists.txt
@@ -25,11 +25,9 @@ ament_auto_add_executable(simple_lidar_simulator src/simple_lidar_simulator.cpp)
 
 target_link_libraries(simple_lidar_simulator ${PCL_LIBRARIES})
 
-install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE launch)
+ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/src/autoware_practice_lidar_simulator/CMakeLists.txt
+++ b/src/autoware_practice_lidar_simulator/CMakeLists.txt
@@ -25,6 +25,8 @@ ament_auto_add_executable(simple_lidar_simulator src/simple_lidar_simulator.cpp)
 
 target_link_libraries(simple_lidar_simulator ${PCL_LIBRARIES})
 
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/src/autoware_practice_lidar_simulator/package.xml
+++ b/src/autoware_practice_lidar_simulator/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>

--- a/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
+++ b/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
@@ -35,8 +35,8 @@ SampleNode::SampleNode() : Node("simple_lidar_simulator")
   timer_ = rclcpp::create_timer(this, get_clock(), period, [this] { on_timer(); });
 
   // 物体の中心位置リストをCSVから読み取って初期化
-  object_centers_ = load_object_centers_from_csv("src/autoware_practice_lidar_simulator/config/object_centers.csv");
-}
+  const auto pkg_path = ament_index_cpp::get_package_share_directory("autoware_practice_lidar_simulator");
+  object_centers_ = load_object_centers_from_csv(pkg_path + "/config/object_centers.csv");}
 
 void SampleNode::pose_callback(const PoseStamped::SharedPtr msg)
 {

--- a/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
+++ b/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
@@ -16,6 +16,8 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
+
 #include <fstream>
 #include <memory>
 #include <sstream>

--- a/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
+++ b/src/autoware_practice_lidar_simulator/src/simple_lidar_simulator.cpp
@@ -14,9 +14,9 @@
 
 #include "simple_lidar_simulator.hpp"
 
-#include <pcl_conversions/pcl_conversions.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <fstream>
 #include <memory>
@@ -38,7 +38,8 @@ SampleNode::SampleNode() : Node("simple_lidar_simulator")
 
   // 物体の中心位置リストをCSVから読み取って初期化
   const auto pkg_path = ament_index_cpp::get_package_share_directory("autoware_practice_lidar_simulator");
-  object_centers_ = load_object_centers_from_csv(pkg_path + "/config/object_centers.csv");}
+  object_centers_ = load_object_centers_from_csv(pkg_path + "/config/object_centers.csv");
+}
 
 void SampleNode::pose_callback(const PoseStamped::SharedPtr msg)
 {


### PR DESCRIPTION
# 課題
simple_lidar_simulator.cpp にて config/object_centers.csv を相対パスで指定しており、 `ros2 launch autoware_practice_launch practice.launch.xml` を実行可能なディレクトリに制約があった

# 対応
config ディレクトリを share に install した

# テスト方法
任意のディレクトリで `ros2 launch autoware_practice_launch practice.launch.xml` が実行可能なことを確認


よろしくお願いいたします。