### PR TITLE
refactor: Add namespace marker

### DIFF
--- a/src/autoware_practice_launch/config/autoware.rviz
+++ b/src/autoware_practice_launch/config/autoware.rviz
@@ -88,7 +88,7 @@ Visualization Manager:
       Name: TrajectoryMarkers
       Namespaces: {}
       Topic:
-        Value: /trajectory_marker
+        Value: /debug/trajectory_marker
         History Policy: Keep Last
         Reliability Policy: Reliable
         Qos Overrides:
@@ -104,7 +104,7 @@ Visualization Manager:
       Name: TrajectoryMarkers
       Namespaces: {}
       Topic:
-        Value: /reference_trajectory_marker
+        Value: /debug/reference_trajectory_marker
         History Policy: Keep Last
         Reliability Policy: Reliable
         Qos Overrides:
@@ -120,7 +120,7 @@ Visualization Manager:
       Name: TrajectoryMarkers
       Namespaces: {}
       Topic:
-        Value: /candidate_trajectory_marker
+        Value: /debug/candidate_trajectory_marker
         History Policy: Keep Last
         Reliability Policy: Reliable
         Qos Overrides:

--- a/src/autoware_practice_visualization/src/marker.cpp
+++ b/src/autoware_practice_visualization/src/marker.cpp
@@ -33,12 +33,12 @@ TrajectoryVisualizer::TrajectoryVisualizer(const rclcpp::NodeOptions & options) 
     "/planning/scenario_planning/costmap", 10,
     std::bind(&TrajectoryVisualizer::costmapCallback, this, std::placeholders::_1));
 
-  marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/trajectory_marker", 10);
+  marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/debug/trajectory_marker", 10);
   reference_marker_pub_ =
-    this->create_publisher<visualization_msgs::msg::MarkerArray>("/reference_trajectory_marker", 10);
+    this->create_publisher<visualization_msgs::msg::MarkerArray>("/debug/reference_trajectory_marker", 10);
   candidate_marker_pub_ =
-    this->create_publisher<visualization_msgs::msg::MarkerArray>("/candidate_trajectory_marker", 10);
-  costmap_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/costmap_marker", 10);
+    this->create_publisher<visualization_msgs::msg::MarkerArray>("/debug/candidate_trajectory_marker", 10);
+  costmap_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/debug/costmap_marker", 10);
 }
 
 void TrajectoryVisualizer::trajectoryCallback(const autoware_auto_planning_msgs::msg::Trajectory::SharedPtr msg)


### PR DESCRIPTION
rvizに表示するためのmarkerのtopic名にdebug namespaceを追加しました。

下記のawfのコーディングルールに準拠しました。
https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/topic-namespaces/
![image](https://github.com/user-attachments/assets/5b8bc2dc-0b27-47b3-b87a-308bb94c04a2)
